### PR TITLE
Enhance csv to md table function

### DIFF
--- a/main.js
+++ b/main.js
@@ -148,9 +148,10 @@ const convertCSVToMarkdown = (content) => {
 
 	let fix = content
 		.replace(/(\S)(\,)((\S)|(\n)|($))/g, csvCommaReplace)
-		.split('\n');
-	const headersplit = '-|'.repeat(
-		fix[0].split('').filter((char) => char === '|').length + 1
+		.split('\n')
+		.map((l) => "|" + l.trim() + "|");
+	const headersplit = '|' + '---|'.repeat(
+		fix[0].split('').filter((char) => char === '|').length -1
 	);
 	fix.splice(1, 0, headersplit);
 	return fix.join('\n');


### PR DESCRIPTION
Hi @connertennery,

I added the beginning `|` and ending `|`. Because if missing, it will cause some plugins in Obsidian not to recognize that it is a markdown table.

Expanding `-|` to `---|` for better formatting of the table
Example CSV
```
Name,Age
Sean,17
Lily,23
```
Before the patch
```
Name|Age
-|-|
Sean|17
Lily|23
```
After the patch
```
|Name|Age|
|---|---|
|Sean|17|
|Lily|23|
```

Let me know if you need additional testing or documentation from me